### PR TITLE
Dockerize + content/style refresh (paves the way for cluster-hosted prod)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.gitignore
+.astro
+dist
+node_modules
+.vscode
+.idea
+*.log
+README.md
+.env
+.env.*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Build and Push Docker Image to Harbor
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Compute tags
+        id: tags
+        run: |
+          # Env-prefixed immutable tag — Argo CD Image Updater watches
+          # `<env>-sha-<short>` per overlay. Prefix MUST match the kustomize
+          # overlay directory name (development / production). Mutable tag
+          # kept for transition / manual rollbacks.
+          SHORT_SHA=${GITHUB_SHA::7}
+          if [ "${{ github.ref_name }}" == "main" ]; then
+            ENV_NAME=production
+            MUTABLE=prod
+          elif [ "${{ github.ref_name }}" == "develop" ]; then
+            ENV_NAME=development
+            MUTABLE=latest
+          else
+            echo "Unsupported branch: ${{ github.ref_name }}"
+            exit 1
+          fi
+          echo "SHA_TAG=${ENV_NAME}-sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "MUTABLE_TAG=${MUTABLE}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Harbor registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.HARBOR_REGISTRY }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Build Docker image
+        run: |
+          IMAGE=${{ secrets.HARBOR_REGISTRY }}/paradaux-public/paradaux-io
+          docker build \
+            -t "${IMAGE}:${{ steps.tags.outputs.SHA_TAG }}" \
+            -t "${IMAGE}:${{ steps.tags.outputs.MUTABLE_TAG }}" \
+            .
+
+      - name: Push Docker image
+        run: |
+          IMAGE=${{ secrets.HARBOR_REGISTRY }}/paradaux-public/paradaux-io
+          docker push "${IMAGE}:${{ steps.tags.outputs.SHA_TAG }}"
+          docker push "${IMAGE}:${{ steps.tags.outputs.MUTABLE_TAG }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: install dependencies ────────────────────────────────────────────
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ── Stage 2: build static site (Astro -> /app/dist) ──────────────────────────
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# ── Stage 3: nginx serving the static output ─────────────────────────────────
+# nginxinc/nginx-unprivileged: listens on 8080 and runs as uid 101 by default,
+# so the pod can run with readOnlyRootFilesystem + non-root securityContext.
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runner
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,36 @@
+server {
+  listen 8080;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  server_tokens off;
+
+  # k8s probes — cheap, bypasses access log
+  location = /healthz {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 "ok\n";
+  }
+
+  # Hashed/static assets — long cache. Astro emits content-hashed filenames
+  # for built JS/CSS, so 7d is conservative; bump to 1y if you trust the hash.
+  location ~* \.(?:css|js|ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|otf|pdf)$ {
+    expires 7d;
+    add_header Cache-Control "public, no-transform";
+    try_files $uri =404;
+  }
+
+  # Pages: Astro generates pretty URLs (/about/index.html for /about). Try
+  # the exact URI, then /<uri>/index.html, then <uri>.html.
+  location / {
+    try_files $uri $uri/index.html $uri.html =404;
+    add_header Cache-Control "no-cache";
+  }
+
+  gzip on;
+  gzip_vary on;
+  gzip_min_length 1024;
+  gzip_types text/plain text/css text/javascript application/javascript application/json image/svg+xml;
+}

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -106,11 +106,13 @@ const TURNSTILE_SITE_KEY = '0x4AAAAAABi05LMDUHvIaiaF';
   }
 
   .section h2 {
-    color: #36454F;
+    color: var(--heading);
     font-size: 1.5rem;
-    margin-bottom: 1rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin-bottom: 1.5rem;
     padding-bottom: 0.5rem;
-    border-bottom: 2px solid #36454F;
+    border-bottom: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
   }
 
   .contact-container {
@@ -122,13 +124,13 @@ const TURNSTILE_SITE_KEY = '0x4AAAAAABi05LMDUHvIaiaF';
 
   .contact-info {
     h3 {
-      color: #36454F;
+      color: var(--heading);
       font-size: 1.2rem;
       margin-bottom: 1rem;
     }
 
     p {
-      color: #6c757d;
+      color: var(--text-muted);
       margin-bottom: 2rem;
       line-height: 1.6;
     }
@@ -144,27 +146,28 @@ const TURNSTILE_SITE_KEY = '0x4AAAAAABi05LMDUHvIaiaF';
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    color: #36454F;
+    color: var(--heading);
 
     svg {
       flex-shrink: 0;
     }
 
     a {
-      color: #36454F;
+      color: var(--accent);
       text-decoration: none;
+      transition: color 0.15s ease;
 
       &:hover {
-        text-decoration: underline;
+        color: var(--accent-hover);
       }
     }
   }
 
   .contact-form {
-    background: #f8f9fa;
+    background: var(--bg-subtle);
     padding: 2rem;
-    border-radius: 8px;
-    border-left: 4px solid #36454F;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
   }
 
   .form-group {
@@ -173,25 +176,28 @@ const TURNSTILE_SITE_KEY = '0x4AAAAAABi05LMDUHvIaiaF';
     label {
       display: block;
       margin-bottom: 0.5rem;
-      color: #36454F;
+      color: var(--heading);
       font-weight: 500;
     }
 
     input, textarea {
       width: 100%;
       padding: 0.75rem;
-      border: 1px solid #ddd;
-      border-radius: 4px;
+      border: 1px solid #d6dae1;
+      border-radius: 8px;
       font-size: 1rem;
-      transition: border-color 0.2s ease;
+      font-family: inherit;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
 
       &:focus {
         outline: none;
-        border-color: #36454F;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
       }
 
-      &:required:invalid {
+      &:user-invalid {
         border-color: #dc3545;
+        box-shadow: 0 0 0 3px color-mix(in srgb, #dc3545 14%, transparent);
       }
     }
 
@@ -206,21 +212,26 @@ const TURNSTILE_SITE_KEY = '0x4AAAAAABi05LMDUHvIaiaF';
   }
 
   .submit-button {
-    background: #36454F;
+    background: var(--accent);
     color: white;
     border: none;
     padding: 0.75rem 2rem;
-    border-radius: 4px;
+    border-radius: 8px;
     font-size: 1rem;
-    font-weight: 500;
+    font-weight: 600;
+    font-family: inherit;
     cursor: pointer;
-    transition: background-color 0.2s ease;
+    transition: background-color 0.2s ease, transform 0.1s ease;
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
 
     &:hover:not(:disabled) {
-      background: #2a3640;
+      background: var(--accent-hover);
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(1px);
     }
 
     &:disabled {

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -3,7 +3,7 @@ import awsBadge from '../assets/badges/aws-certified-developer-associate.png';
 import terraformBadge from '../assets/badges/hashicorp-certified-terraform-associate-003.png';
 import {getTimeSinceString} from "../utils/time";
 
-const timeSinceJoinedJpmorgan = getTimeSinceString(new Date(2024, 8, 1));
+const timeAtSolidroad = getTimeSinceString(new Date(2026, 3, 1));
 
 ---
 <main class="main-content">
@@ -13,9 +13,22 @@ const timeSinceJoinedJpmorgan = getTimeSinceString(new Date(2024, 8, 1));
             <div class="experience-header">
                 <div>
                     <div class="job-title">Software Engineer</div>
+                    <div class="company">Solidroad</div>
+                </div>
+                <div class="duration">04/2026 — Present ({timeAtSolidroad})</div>
+            </div>
+            <ul>
+                <li>Working on making CX teams more effective and more aware of their agents — human or AI.</li>
+            </ul>
+        </div>
+
+        <div class="experience-item">
+            <div class="experience-header">
+                <div>
+                    <div class="job-title">Software Engineer</div>
                     <div class="company">JPMorganChase, Dublin, Ireland</div>
                 </div>
-                <div class="duration">09/2024 — Present ({timeSinceJoinedJpmorgan})</div>
+                <div class="duration">09/2024 — 04/2026 (1 year 7 months)</div>
             </div>
             <ul>
                 <li>
@@ -150,19 +163,26 @@ const timeSinceJoinedJpmorgan = getTimeSinceString(new Date(2024, 8, 1));
   }
 
   .section h2 {
-    color: #36454F;
+    color: var(--heading);
     font-size: 1.5rem;
-    margin-bottom: 1rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin-bottom: 1.5rem;
     padding-bottom: 0.5rem;
-    border-bottom: 2px solid #36454F;
+    border-bottom: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
   }
 
   .experience-item, .project-item, .award-item {
-    margin-bottom: 2rem;
-    padding: 1.5rem;
-    background: #f8f9fa;
-    border-radius: 8px;
-    border-left: 4px solid #36454F;
+    margin-bottom: 1rem;
+    padding: 1.5rem 1.75rem;
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    transition: border-color 0.2s ease;
+  }
+
+  .experience-item:hover, .award-item:hover {
+    border-color: color-mix(in srgb, var(--accent) 22%, var(--border));
   }
 
   .experience-header {
@@ -175,7 +195,7 @@ const timeSinceJoinedJpmorgan = getTimeSinceString(new Date(2024, 8, 1));
 
   .job-title, .award-title {
     font-weight: 600;
-    color: #333;
+    color: var(--heading);
     font-size: 1.1rem;
   }
 
@@ -201,10 +221,13 @@ const timeSinceJoinedJpmorgan = getTimeSinceString(new Date(2024, 8, 1));
   }
 
   .experience-item li::before {
-    content: "▸";
-    color: rgba(54, 69, 79, 0.91);
+    content: "▶";
+    color: var(--accent);
+    font-size: 0.7rem;
+    line-height: 1.6rem;
     position: absolute;
     left: 0;
+    top: 0;
   }
 
   .award-item {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,7 +1,4 @@
 ---
-import { getAge } from '../utils/time.ts';
-
-let age = getAge(new Date(2002, 4, 13));
 ---
 
 <div id="container">
@@ -12,20 +9,14 @@ let age = getAge(new Date(2002, 4, 13));
 				Hi there! I'm Rían<sup id="footnote-ref-1">1</sup>, a Software Developer from Ireland.
 			</p>
 			<p>
-				I'm a {age}-year-old Software Developer from Ireland, currently working at JPMorganChase as a Software Engineer,
-				currently based in Dublin, working within Global Fund Services Technology. I'm interested in building scalable,
-				maintainable and modern full-stack applications.
+				I'm a Software Developer from Ireland, currently working at Solidroad as a Software Engineer. I'm interested in
+				building scalable, maintainable and modern full-stack applications.
 			</p>
 			<p>
 				My background is in Computational Linguistics, which is the intersection of computer science and human language.
 				I've worked on many things and projects over the years, including an internship at Microsoft, where I worked on
 				Azure Communication Services, a constituent part of Microsoft Teams, and as a Software Engineer in Research at
 				Trinity College Dublin, where I worked on Irish speech technology as part of the ABAIR project.
-			</p>
-			<p>
-				I'm interested in working with Irish non-profit organisations to help them streamline their operations, and to
-				that end I'm willing to offer my services for free to any such organisation. If you are interested, please get in touch
-				using the form below.
 			</p>
 
 			<footer class="footnotes">
@@ -65,7 +56,7 @@ let age = getAge(new Date(2002, 4, 13));
 
 	.hero-subtitle {
 		font-size: 1.25rem;
-		color: #6b7280;
+		color: var(--text-muted);
 		max-width: 42rem;
 		margin-left: auto;
 		margin-right: auto;
@@ -92,13 +83,13 @@ let age = getAge(new Date(2002, 4, 13));
 		max-width: 42rem;
 		margin: 2rem auto 0;
 		font-size: 0.875rem;
-		color: #6b7280;
+		color: var(--text-muted);
 		text-align: left;
 	}
 
 	.footnotes hr {
 		border: none;
-		border-top: 1px solid #d1d5db;
+		border-top: 1px solid var(--border);
 		margin-bottom: 0.75rem;
 	}
 </style>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -13,7 +13,7 @@
 
 <style lang="scss">
   .header {
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--border);
   }
 
   .container {
@@ -46,9 +46,10 @@
     text-decoration: none;
     color: inherit;
     cursor: pointer;
+    transition: color 0.15s ease;
 
     &:hover {
-      text-decoration: underline;
+      color: var(--accent);
     }
   }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ import Navbar from "../components/Navbar.astro";
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
+		<link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap" rel="stylesheet">
 		<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer/>
 		<meta name="generator" content={Astro.generator} />
 		<title>Rían Errity | paradaux.io</title>
@@ -20,14 +20,42 @@ import Navbar from "../components/Navbar.astro";
 	</body>
 </html>
 
-<style lang="scss">
+<style is:global lang="scss">
+	:root {
+		--bg: #f7f8fa;
+		--bg-subtle: #ffffff;
+		--text: #1f2933;
+		--text-muted: #6b7280;
+		--heading: #1f2933;
+		--accent: #0d9488;
+		--accent-hover: #0f766e;
+		--border: #e7e9ee;
+		--radius: 12px;
+	}
+
 	html, body {
 		margin: 0;
 		width: 100%;
-		height: 100%;
-		font-family: "Open Sans", sans-serif;
-		font-optical-sizing: auto;
-		font-style: normal;
-		font-variation-settings: "wdth" 100;
+		min-height: 100%;
+		font-family: "Geist", system-ui, -apple-system, sans-serif;
+		color: var(--text);
+		background: var(--bg);
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		text-rendering: optimizeLegibility;
+	}
+
+	a {
+		color: var(--accent);
+		text-decoration: none;
+		transition: color 0.15s ease;
+	}
+
+	a:hover {
+		color: var(--accent-hover);
+	}
+
+	::selection {
+		background: color-mix(in srgb, var(--accent) 22%, transparent);
 	}
 </style>

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,17 +1,3 @@
-export const getAge = (birthDate: Date) => {
-    const today = new Date();
-
-    let age = today.getFullYear() - birthDate.getFullYear();
-    const monthDiff = today.getMonth() - birthDate.getMonth();
-    const dayDiff = today.getDate() - birthDate.getDate();
-
-    if (monthDiff < 0 || (monthDiff === 0 && dayDiff < 0)) {
-        age--;
-    }
-
-    return age;
-}
-
 export const getTimeSinceString = (pastDate: Date): string => {
     const now = new Date();
     const past = new Date(pastDate);


### PR DESCRIPTION
Two unrelated-but-stacked things land together because they're both already on `develop` and there's no real prod yet to leak them separately to.

## Summary

- **Dockerize** for the cluster cutover. `Dockerfile` (node:22-alpine build → nginxinc/nginx-unprivileged serve), `nginx.conf` (pretty-URL handling, /healthz, gzip, 7d cache on hashed assets), `.dockerignore`, and a `docker-publish.yml` workflow matching the cloccarium-tokens pattern (env-prefixed `<env>-sha-<short>` tag for Argo Image Updater + mutable `latest`/`prod` for rollback). Merging this fires the first `production-sha-<short>` build into Harbor.

- **Content + style refresh**: removed age, swapped JPMorgan-as-current → Solidroad (04/2026—present), capped JPMorgan at 09/2024—04/2026 (1y 7m), dropped the non-profit paragraph, removed unused `getAge()`. Visually: Inter → Geist, design tokens via `:root`, flat card design (white cards on faint grey page, thin border, no shadows), tightened section heading rule to a 1px light-teal full-width line, heavier ▶ bullet glyph with line-height matched to text baseline, form `:user-invalid` fix for the red-on-load bug, subtler hover.

## What this enables

After merge:

1. GHA builds + pushes `harbor.paradaux.io/paradaux-public/paradaux-io:production-sha-<short>` to Harbor.
2. The k8s-gitops `apps/paradaux-io/overlays/production/` (committed locally, pending push) materializes the production deployment + `paradaux.io` apex HTTPRoute.
3. Pre-flip verification via `curl -sI --resolve paradaux.io:443:<node-ip> https://paradaux.io/`.
4. Cloudflare DNS flip off Pages → cluster nodes.
5. Disable the Cloudflare Pages project.

## Known gotcha (not addressed here)

`src/utils/contact.js` still hard-codes `https://api.paradaux.io/api/contact`. Correct for prod, but means the dev site POSTs contact submissions to the prod API. Env-tokenize in a follow-up PR.

## Test plan

- [ ] GHA workflow goes green and pushes `production-sha-<short>` to Harbor
- [ ] (post-merge, separate step) k8s-gitops production overlay pushed + Argo brings the pod up
- [ ] `curl -sI --resolve paradaux.io:443:51.178.64.202 https://paradaux.io/` returns 200 with the new content before any DNS changes
- [ ] After DNS flip, real `https://paradaux.io` loads, logs flow into Loki

🤖 Generated with [Claude Code](https://claude.com/claude-code)